### PR TITLE
Fixing not closing dropdown when event catcher is clicked

### DIFF
--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -27,7 +27,6 @@ export default class Timeline extends React.Component {
    };
 
    render() {
-      console.log(this.state.steps);
       let dif = this.state.max - this.state.min;
 
       const strips = _.range(this.state.steps + 1).map(() => (
@@ -35,9 +34,11 @@ export default class Timeline extends React.Component {
             <div className="inner-strip" />
          </div>
       ));
-      const stripValues = _.range(this.state.min, this.state.max + dif / this.state.steps, dif / this.state.steps).map(
-         stripValue => <span>{stripValue}</span>
-      );
+      const stripValues = _.range(
+         this.state.min,
+         this.state.max + dif / this.state.steps,
+         dif / this.state.steps
+      ).map(stripValue => <span>{stripValue}</span>);
 
       return (
          <div className="timeline-background" onWheel={this.onScroll}>

--- a/src/components/dropdown/Dropdown.jsx
+++ b/src/components/dropdown/Dropdown.jsx
@@ -142,18 +142,23 @@ export default class Dropdown extends React.Component {
       return this.state.calculateDirection(dropdownSizes, openerSizes);
    };
 
+   closeDropDown = () => {
+      this.setState({ isOpened: false });
+   };
+
    render() {
       return (
-         <div
-            className="dropdown"
-            ref={this.state.opennerHolderRef}
-            onMouseLeave={() => this.setState({ isOpened: false })}>
+         <div className="dropdown" ref={this.state.opennerHolderRef} onMouseLeave={this.closeDropDown}>
             <div className="dropdownContent" {...this.state.openActions}>
                {this.props.content}
             </div>
             {this.getExpandedDropdown()}
 
-            <div className="dropdownEventCatcher" style={this.getStylesForEventCatcher()} />
+            <div
+               className="dropdownEventCatcher"
+               onClick={this.closeDropDown}
+               style={this.getStylesForEventCatcher()}
+            />
          </div>
       );
    }


### PR DESCRIPTION
Dropdown can be opened on mouse hover, but when mouse is moved out of dropdown and user clicks, dropdown is not hidden. I added click event on event catcher that change dropdown visibility state to hidden.